### PR TITLE
Add settings panel for configuring DSE filters

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "dse-hie-meitech-web",
+  "name": "dse-hie-meitech",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "dse-hie-meitech-web",
+      "name": "dse-hie-meitech",
       "version": "1.0.0",
       "dependencies": {
         "express": "^4.19.2",

--- a/src/client/src/components/FilterSettingsPanel.tsx
+++ b/src/client/src/components/FilterSettingsPanel.tsx
@@ -1,0 +1,374 @@
+import { FormEvent, useCallback, useEffect, useRef, useState } from "react";
+import { useJetBus } from "../context/JetBusContext";
+import type { FilterMode, FilterStageConfig, FiltersResponse } from "../types/filters";
+import { cn } from "../utils/cn";
+
+const FILTER_OPTIONS: Array<{ value: FilterMode; label: string }> = [
+  { value: "NoFilter", label: "Sem filtro" },
+  { value: "FIRCombFilter", label: "FIR Comb Filter" },
+  { value: "FIRMovingAverage", label: "FIR Moving Average" }
+];
+
+const MODE_DESCRIPTIONS: Record<FilterMode, string> = {
+  NoFilter: "Desativa o filtro digital neste estágio.",
+  FIRCombFilter: "Remove componentes periódicas do sinal com um filtro comb FIR.",
+  FIRMovingAverage: "Suaviza ruídos de alta frequência com média móvel FIR."
+};
+
+const STAGES = [2, 3, 4, 5] as const;
+type Stage = (typeof STAGES)[number];
+
+type StageFormState = {
+  mode: FilterMode;
+  cutOffFrequency: string;
+};
+
+type StageStatus = {
+  state: "idle" | "loading" | "success" | "error";
+  message?: string;
+};
+
+type StageFormMap = Partial<Record<Stage, StageFormState>>;
+type StageStatusMap = Partial<Record<Stage, StageStatus>>;
+type StageTimeoutMap = Partial<Record<Stage, ReturnType<typeof setTimeout>>>;
+
+async function requestJson<T>(input: RequestInfo | URL, init?: RequestInit): Promise<T> {
+  const response = await fetch(input, init);
+  let payload: unknown;
+  try {
+    payload = await response.json();
+  } catch {
+    payload = undefined;
+  }
+  if (!response.ok) {
+    const message =
+      payload && typeof payload === "object" && payload !== null && "error" in payload
+        ? String((payload as { error?: string }).error ?? `Erro HTTP ${response.status}`)
+        : `Erro HTTP ${response.status}`;
+    throw new Error(message);
+  }
+  return (payload ?? {}) as T;
+}
+
+function mapStagesToForm(stages: FilterStageConfig[]): StageFormMap {
+  const map: StageFormMap = {};
+  STAGES.forEach((stage) => {
+    const entry = stages.find((candidate) => candidate.stage === stage);
+    if (entry) {
+      map[stage] = {
+        mode: entry.mode,
+        cutOffFrequency: String(entry.cutOffFrequency ?? 0)
+      };
+    } else {
+      map[stage] = {
+        mode: "NoFilter",
+        cutOffFrequency: "0"
+      };
+    }
+  });
+  return map;
+}
+
+interface FilterSettingsPanelProps {
+  className?: string;
+}
+
+function FilterSettingsPanel({ className }: FilterSettingsPanelProps): JSX.Element {
+  const { notify, state } = useJetBus();
+  const connected = Boolean(state.connected);
+  const [loading, setLoading] = useState<boolean>(false);
+  const [formState, setFormState] = useState<StageFormMap>({});
+  const [statuses, setStatuses] = useState<StageStatusMap>({});
+  const [error, setError] = useState<string | null>(null);
+  const resetTimers = useRef<StageTimeoutMap>({});
+
+  const clearStageTimer = useCallback((stage: Stage) => {
+    const timer = resetTimers.current[stage];
+    if (timer) {
+      clearTimeout(timer);
+      delete resetTimers.current[stage];
+    }
+  }, []);
+
+  const scheduleStatusReset = useCallback((stage: Stage) => {
+    clearStageTimer(stage);
+    resetTimers.current[stage] = setTimeout(() => {
+      setStatuses((prev) => {
+        const next = { ...prev };
+        delete next[stage];
+        return next;
+      });
+      delete resetTimers.current[stage];
+    }, 4000);
+  }, [clearStageTimer]);
+
+  useEffect(() => () => {
+    STAGES.forEach((stage) => {
+      const timer = resetTimers.current[stage];
+      if (timer) {
+        clearTimeout(timer);
+      }
+    });
+  }, []);
+
+  const applyConfiguration = useCallback((stages: FilterStageConfig[]) => {
+    setFormState(mapStagesToForm(stages));
+  }, []);
+
+  const fetchFilters = useCallback(async () => {
+    if (!connected) {
+      setFormState({});
+      setStatuses({});
+      setError(null);
+      setLoading(false);
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await requestJson<FiltersResponse>("/api/filters");
+      applyConfiguration(response.stages);
+      setStatuses({});
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Não foi possível carregar os filtros.";
+      setError(message);
+      notify("error", "Filtros digitais", message);
+    } finally {
+      setLoading(false);
+    }
+  }, [applyConfiguration, connected, notify]);
+
+  useEffect(() => {
+    void fetchFilters();
+  }, [fetchFilters]);
+
+  const handleModeChange = useCallback((stage: Stage, value: FilterMode) => {
+    setFormState((prev) => {
+      const current = prev[stage] ?? { mode: value, cutOffFrequency: value === "NoFilter" ? "0" : "" };
+      return {
+        ...prev,
+        [stage]: {
+          mode: value,
+          cutOffFrequency: value === "NoFilter" ? "0" : current.cutOffFrequency || "0"
+        }
+      };
+    });
+  }, []);
+
+  const handleFrequencyChange = useCallback((stage: Stage, value: string) => {
+    setFormState((prev) => {
+      const current = prev[stage] ?? { mode: "NoFilter", cutOffFrequency: "0" };
+      return {
+        ...prev,
+        [stage]: {
+          mode: current.mode,
+          cutOffFrequency: value
+        }
+      };
+    });
+  }, []);
+
+  const handleSubmit = useCallback(
+    async (event: FormEvent<HTMLFormElement>, stage: Stage) => {
+      event.preventDefault();
+      if (!connected) {
+        return;
+      }
+      const form = formState[stage] ?? { mode: "NoFilter", cutOffFrequency: "0" };
+      if (form.mode !== "NoFilter") {
+        const trimmed = form.cutOffFrequency.trim();
+        if (trimmed.length === 0) {
+          setStatuses((prev) => ({
+            ...prev,
+            [stage]: { state: "error", message: "Informe a frequência de corte." }
+          }));
+          scheduleStatusReset(stage);
+          return;
+        }
+        const numeric = Number(trimmed);
+        if (!Number.isFinite(numeric) || numeric < 0) {
+          setStatuses((prev) => ({
+            ...prev,
+            [stage]: { state: "error", message: "Frequência inválida." }
+          }));
+          scheduleStatusReset(stage);
+          return;
+        }
+      }
+
+      const frequencyValue = form.mode === "NoFilter" ? 0 : Number(form.cutOffFrequency.trim());
+      if (form.mode !== "NoFilter" && (!Number.isFinite(frequencyValue) || frequencyValue < 0)) {
+        setStatuses((prev) => ({
+          ...prev,
+          [stage]: { state: "error", message: "Frequência inválida." }
+        }));
+        scheduleStatusReset(stage);
+        return;
+      }
+
+      clearStageTimer(stage);
+      setStatuses((prev) => ({ ...prev, [stage]: { state: "loading" } }));
+
+      try {
+        const response = await requestJson<FiltersResponse>("/api/filters", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            stage,
+            mode: form.mode,
+            cutOffFrequency: frequencyValue
+          })
+        });
+        applyConfiguration(response.stages);
+        setStatuses((prev) => ({
+          ...prev,
+          [stage]: { state: "success", message: "Configuração aplicada." }
+        }));
+        scheduleStatusReset(stage);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : "Falha ao aplicar a configuração.";
+        setStatuses((prev) => ({
+          ...prev,
+          [stage]: { state: "error", message }
+        }));
+        scheduleStatusReset(stage);
+        notify("error", "Filtros digitais", message);
+      }
+    },
+    [applyConfiguration, clearStageTimer, connected, formState, notify, scheduleStatusReset]
+  );
+
+  return (
+    <section className={cn("w-full", className)}>
+      <div className="panel flex h-full flex-col gap-6">
+        <div className="flex flex-wrap items-start justify-between gap-4">
+          <div>
+            <h2 className="text-xl font-semibold text-slate-100">Filtros Digitais</h2>
+            <p className="text-sm text-slate-300">
+              Configure o modo e a frequência de corte de cada estágio do processamento DSE.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={() => void fetchFilters()}
+            disabled={!connected || loading}
+            className={cn(
+              "rounded-xl border border-slate-500/50 bg-slate-900/70 px-4 py-2 text-sm font-medium text-slate-200 transition",
+              (!connected || loading) && "cursor-not-allowed opacity-40"
+            )}
+          >
+            Atualizar
+          </button>
+        </div>
+
+        {!connected && (
+          <div className="rounded-xl border border-slate-500/40 bg-slate-900/70 px-4 py-3 text-sm text-slate-300">
+            Conecte-se ao dispositivo para visualizar e alterar as configurações de filtro.
+          </div>
+        )}
+
+        {error && (
+          <div className="rounded-xl border border-rose-500/40 bg-rose-500/10 px-4 py-3 text-sm text-rose-200">
+            {error}
+          </div>
+        )}
+
+        {connected && loading && (
+          <p className="text-sm text-slate-300">Carregando configurações atuais...</p>
+        )}
+
+        <div className="grid grid-cols-1 gap-5 md:grid-cols-2">
+          {STAGES.map((stage) => {
+            const form = formState[stage] ?? {
+              mode: connected ? "NoFilter" : "NoFilter",
+              cutOffFrequency: connected ? "0" : ""
+            };
+            const status = statuses[stage];
+            const isApplying = status?.state === "loading";
+            const disableControls = !connected || loading || isApplying;
+            const frequencyDisabled = disableControls || form.mode === "NoFilter";
+            const frequencyPlaceholder = form.mode === "NoFilter" ? "—" : "mHz";
+            const frequencyValue = form.mode === "NoFilter" ? (connected ? "0" : "") : form.cutOffFrequency;
+
+            return (
+              <form
+                key={stage}
+                onSubmit={(event) => void handleSubmit(event, stage)}
+                className="flex flex-col gap-4 rounded-2xl border border-slate-500/30 bg-slate-900/70 p-5 shadow-inner shadow-slate-900/30"
+              >
+                <div className="flex items-center justify-between gap-2">
+                  <h3 className="text-lg font-semibold text-slate-100">Estágio {stage}</h3>
+                  {status?.state === "success" && (
+                    <span className="text-sm font-medium text-emerald-300">{status.message ?? "Configuração aplicada."}</span>
+                  )}
+                  {status?.state === "error" && (
+                    <span className="text-sm font-medium text-rose-300">{status.message}</span>
+                  )}
+                  {status?.state === "loading" && (
+                    <span className="text-sm font-medium text-slate-300">Aplicando...</span>
+                  )}
+                </div>
+
+                <label className="flex flex-col gap-2">
+                  <span className="text-sm font-medium text-slate-300">Tipo de filtro</span>
+                  <select
+                    value={form.mode}
+                    onChange={(event) => handleModeChange(stage, event.target.value as FilterMode)}
+                    disabled={disableControls}
+                    className={cn(
+                      "rounded-xl border border-slate-600/50 bg-slate-950/80 px-4 py-2 text-sm text-slate-100 shadow-inner focus:outline focus:outline-2 focus:outline-offset-2 focus:outline-sky-400",
+                      disableControls && "cursor-not-allowed opacity-60"
+                    )}
+                  >
+                    {FILTER_OPTIONS.map((option) => (
+                      <option key={option.value} value={option.value}>
+                        {option.label}
+                      </option>
+                    ))}
+                  </select>
+                  <span className="text-xs text-slate-400">{MODE_DESCRIPTIONS[form.mode]}</span>
+                </label>
+
+                <label className="flex flex-col gap-2">
+                  <span className="text-sm font-medium text-slate-300">Frequência de corte (mHz)</span>
+                  <input
+                    type="number"
+                    inputMode="numeric"
+                    min={0}
+                    step={1}
+                    value={frequencyValue}
+                    placeholder={frequencyPlaceholder}
+                    onChange={(event) => handleFrequencyChange(stage, event.target.value)}
+                    disabled={frequencyDisabled}
+                    className={cn(
+                      "rounded-xl border border-slate-600/50 bg-slate-950/80 px-4 py-2 text-sm text-slate-100 shadow-inner placeholder:text-slate-500 focus:outline focus:outline-2 focus:outline-offset-2 focus:outline-sky-400",
+                      frequencyDisabled && "cursor-not-allowed opacity-60"
+                    )}
+                  />
+                  <span className="text-xs text-slate-400">
+                    Valores em milihertz. Use 0 para deixar o estágio sem corte adicional.
+                  </span>
+                </label>
+
+                <div className="flex items-center justify-between gap-3">
+                  <button
+                    type="submit"
+                    disabled={disableControls}
+                    className={cn(
+                      "rounded-xl bg-gradient-to-r from-sky-400 to-indigo-500 px-4 py-2 text-sm font-semibold text-slate-900 shadow-brand-lg transition-transform hover:-translate-y-0.5 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-400",
+                      disableControls && "cursor-not-allowed opacity-40"
+                    )}
+                  >
+                    Aplicar alterações
+                  </button>
+                </div>
+              </form>
+            );
+          })}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export default FilterSettingsPanel;

--- a/src/client/src/pages/SettingsPage.tsx
+++ b/src/client/src/pages/SettingsPage.tsx
@@ -1,5 +1,6 @@
 import { Link } from "react-router-dom";
 import ActionsGrid from "../components/ActionsGrid";
+import FilterSettingsPanel from "../components/FilterSettingsPanel";
 import LogPanel from "../components/LogPanel";
 import PageContainer from "../components/PageContainer";
 
@@ -20,7 +21,10 @@ function SettingsPage(): JSX.Element {
       </div>
 
       <div className="grid flex-1 min-h-0 grid-cols-1 gap-8 auto-rows-fr xl:grid-cols-12 xl:items-start">
-        <ActionsGrid className="h-full xl:col-span-9" />
+        <div className="flex min-h-0 flex-col gap-8 xl:col-span-9">
+          <FilterSettingsPanel />
+          <ActionsGrid className="h-full" />
+        </div>
         <LogPanel className="h-full xl:col-span-3" />
       </div>
     </PageContainer>

--- a/src/client/src/types/filters.ts
+++ b/src/client/src/types/filters.ts
@@ -1,0 +1,11 @@
+export type FilterMode = "NoFilter" | "FIRCombFilter" | "FIRMovingAverage";
+
+export interface FilterStageConfig {
+  stage: number;
+  mode: FilterMode;
+  cutOffFrequency: number;
+}
+
+export interface FiltersResponse {
+  stages: FilterStageConfig[];
+}

--- a/src/dse/device.ts
+++ b/src/dse/device.ts
@@ -3,7 +3,7 @@ import { Command, commands } from "../jetbus/commands";
 import { ProcessData } from "../jetbus/processData";
 import { doubleToDigit } from "../jetbus/measurementUtils";
 import { JetBusError } from "../jetbus/types";
-import { TareMode } from "./types";
+import { FilterType, TareMode } from "./types";
 
 const SCALE_COMMAND_CALIBRATE_ZERO = 2053923171;
 const SCALE_COMMAND_CALIBRATE_NOMINAL = 1852596579;
@@ -13,6 +13,36 @@ const SCALE_COMMAND_SET_GROSS = 1936683623;
 const DEFAULT_COMMAND_TIMEOUT = 10_000;
 const PROCESS_DATA_TIMEOUT = 5_000;
 const MVV_TO_D_CONVERSION = 1_000_000;
+
+export type FilterStage = 2 | 3 | 4 | 5;
+
+const FILTER_STAGE_ORDER: readonly FilterStage[] = [2, 3, 4, 5];
+
+const FILTER_STAGE_COMMANDS: Record<FilterStage, Command> = {
+  2: commands.dseFilterModeStage2(),
+  3: commands.dseFilterModeStage3(),
+  4: commands.dseFilterModeStage4(),
+  5: commands.dseFilterModeStage5()
+};
+
+const COMB_FILTER_FREQUENCY_COMMANDS: Record<FilterStage, Command> = {
+  2: commands.dseCombFilterFrequencyStage2(),
+  3: commands.dseCombFilterFrequencyStage3(),
+  4: commands.dseCombFilterFrequencyStage4(),
+  5: commands.dseCombFilterFrequencyStage5()
+};
+
+const MOVING_AVERAGE_FREQUENCY_COMMANDS: Record<FilterStage, Command> = {
+  2: commands.dseMovAvFilterFrequencyStage2(),
+  3: commands.dseMovAvFilterFrequencyStage3(),
+  4: commands.dseMovAvFilterFrequencyStage4(),
+  5: commands.dseMovAvFilterFrequencyStage5()
+};
+
+const FILTER_TYPE_CODES: Record<number, readonly number[]> = {
+  [FilterType.FIRCombFilter]: [13089, 13090, 13091, 13092],
+  [FilterType.FIRMovingAverage]: [13105, 13106, 13107, 13108]
+};
 
 const DEFAULT_FETCH_PATHS = [
   "6002/02",
@@ -31,6 +61,12 @@ const DEFAULT_FETCH_PATHS = [
   "6144/00",
   "6153/00"
 ] as const;
+
+export interface FilterStageConfiguration {
+  stage: FilterStage;
+  mode: FilterType;
+  cutOffFrequency: number;
+}
 
 export interface DeviceOptions {
   clientOptions: JetBusClientOptions;
@@ -241,6 +277,93 @@ export class Device {
     await this.writeInt(commands.dseNominalSignal(), value);
   }
 
+  async filterStage2Mode(): Promise<FilterType> {
+    return this.getFilterStageMode(2);
+  }
+
+  async setFilterStage2Mode(type: FilterType): Promise<void> {
+    await this.setFilterStageMode(2, type);
+  }
+
+  async filterStage3Mode(): Promise<FilterType> {
+    return this.getFilterStageMode(3);
+  }
+
+  async setFilterStage3Mode(type: FilterType): Promise<void> {
+    await this.setFilterStageMode(3, type);
+  }
+
+  async filterStage4Mode(): Promise<FilterType> {
+    return this.getFilterStageMode(4);
+  }
+
+  async setFilterStage4Mode(type: FilterType): Promise<void> {
+    await this.setFilterStageMode(4, type);
+  }
+
+  async filterStage5Mode(): Promise<FilterType> {
+    return this.getFilterStageMode(5);
+  }
+
+  async setFilterStage5Mode(type: FilterType): Promise<void> {
+    await this.setFilterStageMode(5, type);
+  }
+
+  async filterCutOffFrequencyStage2(): Promise<number> {
+    return this.getFilterCutOffFrequency(2);
+  }
+
+  async setFilterCutOffFrequencyStage2(value: number): Promise<void> {
+    await this.setFilterCutOffFrequency(2, value);
+  }
+
+  async filterCutOffFrequencyStage3(): Promise<number> {
+    return this.getFilterCutOffFrequency(3);
+  }
+
+  async setFilterCutOffFrequencyStage3(value: number): Promise<void> {
+    await this.setFilterCutOffFrequency(3, value);
+  }
+
+  async filterCutOffFrequencyStage4(): Promise<number> {
+    return this.getFilterCutOffFrequency(4);
+  }
+
+  async setFilterCutOffFrequencyStage4(value: number): Promise<void> {
+    await this.setFilterCutOffFrequency(4, value);
+  }
+
+  async filterCutOffFrequencyStage5(): Promise<number> {
+    return this.getFilterCutOffFrequency(5);
+  }
+
+  async setFilterCutOffFrequencyStage5(value: number): Promise<void> {
+    await this.setFilterCutOffFrequency(5, value);
+  }
+
+  async filterStagesConfiguration(): Promise<FilterStageConfiguration[]> {
+    const configurations = await Promise.all(
+      FILTER_STAGE_ORDER.map(async (stage) => ({
+        stage,
+        mode: await this.getFilterStageMode(stage),
+        cutOffFrequency: await this.getFilterCutOffFrequency(stage)
+      }))
+    );
+    return configurations;
+  }
+
+  async configureFilterStage(
+    stage: FilterStage,
+    configuration: { mode?: FilterType; cutOffFrequency?: number }
+  ): Promise<void> {
+    if (configuration.mode !== undefined) {
+      await this.setFilterStageMode(stage, configuration.mode);
+    }
+    if (configuration.cutOffFrequency !== undefined) {
+      await this.setFilterCutOffFrequency(stage, configuration.cutOffFrequency);
+    }
+  }
+
   async saveAllParameters(): Promise<void> {
     await this.writeInt(commands.cia461SaveAllParameters(), 0);
   }
@@ -287,6 +410,84 @@ export class Device {
     const capacityD = Math.round((scaleZeroMvv + capacityMvv) * MVV_TO_D_CONVERSION);
     await this.writeInt(commands.ldwZeroValue(), scaleZeroD);
     await this.writeInt(commands.lwtNominalValue(), capacityD);
+  }
+
+  private async getFilterStageMode(stage: FilterStage): Promise<FilterType> {
+    const command = FILTER_STAGE_COMMANDS[stage];
+    const value = await this.readInt(command);
+    return this.normalizeFilterType(value);
+  }
+
+  private async setFilterStageMode(stage: FilterStage, type: FilterType): Promise<void> {
+    const command = FILTER_STAGE_COMMANDS[stage];
+    const currentValue = await this.readInt(command);
+    const currentType = this.normalizeFilterType(currentValue);
+    if (currentType === type) {
+      return;
+    }
+    const valueToWrite = await this.determineFilterCode(stage, type);
+    await this.writeInt(command, valueToWrite);
+  }
+
+  private async determineFilterCode(stage: FilterStage, type: FilterType): Promise<number> {
+    if (type === FilterType.NoFilter) {
+      return 0;
+    }
+    const candidates = FILTER_TYPE_CODES[type];
+    if (!candidates || candidates.length === 0) {
+      return 0;
+    }
+    const values = await Promise.all(
+      FILTER_STAGE_ORDER.map((filterStage) => this.readInt(FILTER_STAGE_COMMANDS[filterStage]))
+    );
+    const stageIndex = FILTER_STAGE_ORDER.indexOf(stage);
+    if (stageIndex >= 0) {
+      values[stageIndex] = 0;
+    }
+    for (const candidate of candidates) {
+      if (!values.includes(candidate)) {
+        return candidate;
+      }
+    }
+    return candidates[0];
+  }
+
+  private async getFilterCutOffFrequency(stage: FilterStage): Promise<number> {
+    const mode = await this.getFilterStageMode(stage);
+    switch (mode) {
+      case FilterType.NoFilter:
+        return 0;
+      case FilterType.FIRCombFilter:
+        return this.readInt(COMB_FILTER_FREQUENCY_COMMANDS[stage]);
+      case FilterType.FIRMovingAverage:
+        return this.readInt(MOVING_AVERAGE_FREQUENCY_COMMANDS[stage]);
+      default:
+        return 0;
+    }
+  }
+
+  private async setFilterCutOffFrequency(stage: FilterStage, frequency: number): Promise<void> {
+    const mode = await this.getFilterStageMode(stage);
+    switch (mode) {
+      case FilterType.FIRCombFilter:
+        await this.writeInt(COMB_FILTER_FREQUENCY_COMMANDS[stage], frequency);
+        break;
+      case FilterType.FIRMovingAverage:
+        await this.writeInt(MOVING_AVERAGE_FREQUENCY_COMMANDS[stage], frequency);
+        break;
+      default:
+        break;
+    }
+  }
+
+  private normalizeFilterType(value: number): FilterType {
+    if (value > 13104) {
+      return FilterType.FIRMovingAverage;
+    }
+    if (value > 13088 && value < 13094) {
+      return FilterType.FIRCombFilter;
+    }
+    return FilterType.NoFilter;
   }
 
   private async ensureValue(command: Command, timeout: number): Promise<string> {

--- a/src/dse/types.ts
+++ b/src/dse/types.ts
@@ -21,3 +21,9 @@ export interface PrintableWeightValues {
   gross: string;
   tare: string;
 }
+
+export enum FilterType {
+  NoFilter = 0,
+  FIRCombFilter = 13089,
+  FIRMovingAverage = 13105
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,6 +58,30 @@ async function start(): Promise<void> {
     res.json({ actions: deviceActions });
   });
 
+  app.get("/api/filters", async (_req, res, next) => {
+    try {
+      const stages = await manager.getFilterConfiguration();
+      res.json({ stages });
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  app.post("/api/filters", async (req, res, next) => {
+    const { stage, mode, cutOffFrequency } = req.body ?? {};
+    if (typeof stage !== "number" || Number.isNaN(stage)) {
+      res.status(400).json({ error: "stage must be a number" });
+      return;
+    }
+    try {
+      await manager.updateFilterStage(stage, { mode, cutOffFrequency });
+      const stages = await manager.getFilterConfiguration();
+      res.json({ stages });
+    } catch (error) {
+      next(error);
+    }
+  });
+
   app.post("/api/connect", async (_req, res, next) => {
     try {
       const state = await manager.connect();

--- a/src/jetbus/commands.ts
+++ b/src/jetbus/commands.ts
@@ -101,6 +101,18 @@ function setupRegistry(): void {
   register(makeCommand("DSEFirmwareVersion", DataType.Ascii, "100A/00"));
   register(makeCommand("DSEZeroSignal", DataType.S32, "6150/00"));
   register(makeCommand("DSENominalSignal", DataType.S32, "6151/00"));
+  register(makeCommand("DSEFilterModeStage2", DataType.U32, "6040/02"));
+  register(makeCommand("DSEFilterModeStage3", DataType.U32, "6040/03"));
+  register(makeCommand("DSEFilterModeStage4", DataType.U32, "6040/04"));
+  register(makeCommand("DSEFilterModeStage5", DataType.U32, "6040/05"));
+  register(makeCommand("DSECombFilterFrequencyStage2", DataType.U32, "3321/00"));
+  register(makeCommand("DSECombFilterFrequencyStage3", DataType.U32, "3322/00"));
+  register(makeCommand("DSECombFilterFrequencyStage4", DataType.U32, "3323/00"));
+  register(makeCommand("DSECombFilterFrequencyStage5", DataType.U32, "3324/00"));
+  register(makeCommand("DSEMovAvFilterFrequencyStage2", DataType.U32, "3331/00"));
+  register(makeCommand("DSEMovAvFilterFrequencyStage3", DataType.U32, "3332/00"));
+  register(makeCommand("DSEMovAvFilterFrequencyStage4", DataType.U32, "3333/00"));
+  register(makeCommand("DSEMovAvFilterFrequencyStage5", DataType.U32, "3334/00"));
   register(makeCommand("LDWZeroValue", DataType.S32, "2110/06"));
   register(makeCommand("LWTNominalValue", DataType.S32, "2110/07"));
   register(makeCommand("IMDApplicationMode", DataType.U08, "2010/07"));
@@ -151,6 +163,18 @@ export const commands = {
   dseFirmwareVersion: () => lookup("DSEFirmwareVersion"),
   dseZeroSignal: () => lookup("DSEZeroSignal"),
   dseNominalSignal: () => lookup("DSENominalSignal"),
+  dseFilterModeStage2: () => lookup("DSEFilterModeStage2"),
+  dseFilterModeStage3: () => lookup("DSEFilterModeStage3"),
+  dseFilterModeStage4: () => lookup("DSEFilterModeStage4"),
+  dseFilterModeStage5: () => lookup("DSEFilterModeStage5"),
+  dseCombFilterFrequencyStage2: () => lookup("DSECombFilterFrequencyStage2"),
+  dseCombFilterFrequencyStage3: () => lookup("DSECombFilterFrequencyStage3"),
+  dseCombFilterFrequencyStage4: () => lookup("DSECombFilterFrequencyStage4"),
+  dseCombFilterFrequencyStage5: () => lookup("DSECombFilterFrequencyStage5"),
+  dseMovAvFilterFrequencyStage2: () => lookup("DSEMovAvFilterFrequencyStage2"),
+  dseMovAvFilterFrequencyStage3: () => lookup("DSEMovAvFilterFrequencyStage3"),
+  dseMovAvFilterFrequencyStage4: () => lookup("DSEMovAvFilterFrequencyStage4"),
+  dseMovAvFilterFrequencyStage5: () => lookup("DSEMovAvFilterFrequencyStage5"),
   ldwZeroValue: () => lookup("LDWZeroValue"),
   lwtNominalValue: () => lookup("LWTNominalValue"),
   stoRecordWeight: () => lookup("STORecordWeight"),

--- a/src/server/deviceManager.ts
+++ b/src/server/deviceManager.ts
@@ -1,5 +1,5 @@
-import { Device, DeviceOptions } from "../dse/device";
-import { PrintableWeightValues, TareMode, WeightValues } from "../dse/types";
+import { Device, DeviceOptions, FilterStage } from "../dse/device";
+import { FilterType, PrintableWeightValues, TareMode, WeightValues } from "../dse/types";
 import { ProcessData } from "../jetbus/processData";
 import { JetBusError } from "../jetbus/types";
 
@@ -30,6 +30,33 @@ export interface DeviceState {
 }
 
 export type DeviceEventListener = (snapshot: ProcessDataSnapshot) => void;
+
+export type FilterTypeName = "NoFilter" | "FIRCombFilter" | "FIRMovingAverage";
+
+export interface FilterStageState {
+  stage: FilterStage;
+  mode: FilterTypeName;
+  cutOffFrequency: number;
+}
+
+export interface FilterStageUpdateInput {
+  mode?: string;
+  cutOffFrequency?: number | string;
+}
+
+const FILTER_STAGE_VALUES: readonly FilterStage[] = [2, 3, 4, 5];
+
+const FILTER_TYPE_NAME_BY_VALUE: Record<FilterType, FilterTypeName> = {
+  [FilterType.NoFilter]: "NoFilter",
+  [FilterType.FIRCombFilter]: "FIRCombFilter",
+  [FilterType.FIRMovingAverage]: "FIRMovingAverage"
+};
+
+const FILTER_TYPE_VALUE_BY_NAME: Record<FilterTypeName, FilterType> = {
+  NoFilter: FilterType.NoFilter,
+  FIRCombFilter: FilterType.FIRCombFilter,
+  FIRMovingAverage: FilterType.FIRMovingAverage
+};
 
 export class DeviceManager {
   private readonly device: Device;
@@ -170,6 +197,46 @@ export class DeviceManager {
       default:
         throw new JetBusError(`Unknown action: ${action}`);
     }
+  }
+
+  async getFilterConfiguration(): Promise<FilterStageState[]> {
+    await this.requireConnection();
+    const configuration = await this.device.filterStagesConfiguration();
+    return configuration.map((stageConfig) => ({
+      stage: stageConfig.stage,
+      mode: FILTER_TYPE_NAME_BY_VALUE[stageConfig.mode],
+      cutOffFrequency: stageConfig.cutOffFrequency
+    }));
+  }
+
+  async updateFilterStage(stage: number, configuration: FilterStageUpdateInput): Promise<void> {
+    await this.requireConnection();
+    if (!FILTER_STAGE_VALUES.includes(stage as FilterStage)) {
+      throw new JetBusError("stage must be one of 2, 3, 4 or 5");
+    }
+
+    const update: { mode?: FilterType; cutOffFrequency?: number } = {};
+
+    if (configuration.mode !== undefined) {
+      const normalized = String(configuration.mode) as FilterTypeName;
+      const mapped = FILTER_TYPE_VALUE_BY_NAME[normalized];
+      if (mapped === undefined) {
+        throw new JetBusError(`Unsupported filter mode: ${configuration.mode}`);
+      }
+      update.mode = mapped;
+    }
+
+    if (configuration.cutOffFrequency !== undefined) {
+      const numeric = Number(configuration.cutOffFrequency);
+      this.assertNumber(numeric, "cutOffFrequency");
+      update.cutOffFrequency = numeric;
+    }
+
+    if (Object.keys(update).length === 0) {
+      return;
+    }
+
+    await this.device.configureFilterStage(stage as FilterStage, update);
   }
 
   private async requireConnection(): Promise<void> {

--- a/tests/deviceFilters.test.ts
+++ b/tests/deviceFilters.test.ts
@@ -1,0 +1,152 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { Device } from "../src/dse/device";
+import { FilterType } from "../src/dse/types";
+import { commands } from "../src/jetbus/commands";
+
+class FakeJetBusClient {
+  public readonly cache = new Map<string, string>();
+  public readonly setCalls: Array<{ path: string; value: number }> = [];
+
+  connect(): void {}
+
+  disconnect(): void {}
+
+  setDataCallback(): void {}
+
+  setFetchCallback(): void {}
+
+  snapshot(): Map<string, string> {
+    return new Map(this.cache);
+  }
+
+  readCached(path: string): string | undefined {
+    return this.cache.get(path);
+  }
+
+  async set(path: string, value: unknown): Promise<void> {
+    const numeric = typeof value === "number" ? value : Number(value);
+    this.setCalls.push({ path, value: numeric });
+    this.cache.set(path, String(value));
+  }
+
+  async fetch(): Promise<string> {
+    return "token";
+  }
+
+  async unfetch(): Promise<void> {}
+
+  async waitFor(): Promise<boolean> {
+    return true;
+  }
+}
+
+function createDevice(fakeClient: FakeJetBusClient): Device {
+  const device = new Device({
+    clientOptions: { url: "ws://localhost" },
+    autoFetchProcessData: false
+  });
+  (device as unknown as { client: FakeJetBusClient }).client = fakeClient;
+  return device;
+}
+
+describe("Device digital filters", () => {
+  let fakeClient: FakeJetBusClient;
+  let device: Device;
+
+  beforeEach(() => {
+    fakeClient = new FakeJetBusClient();
+    FILTER_STAGE_PATHS.forEach((path) => {
+      fakeClient.cache.set(path, "0");
+    });
+    device = createDevice(fakeClient);
+  });
+
+  it("normalizes stored filter codes when reading stage mode", async () => {
+    fakeClient.cache.set(commands.dseFilterModeStage2().path, "13090");
+
+    const mode = await device.filterStage2Mode();
+
+    expect(mode).toBe(FilterType.FIRCombFilter);
+  });
+
+  it("selects the lowest available code for the desired filter type", async () => {
+    fakeClient.cache.set(commands.dseFilterModeStage2().path, "13089");
+    fakeClient.cache.set(commands.dseFilterModeStage4().path, "13090");
+
+    await device.setFilterStage3Mode(FilterType.FIRCombFilter);
+
+    expect(fakeClient.setCalls.at(-1)).toEqual({
+      path: commands.dseFilterModeStage3().path,
+      value: 13091
+    });
+  });
+
+  it("returns the configured cut-off frequency for moving average filters", async () => {
+    fakeClient.cache.set(commands.dseFilterModeStage4().path, "13107");
+    fakeClient.cache.set(commands.dseMovAvFilterFrequencyStage4().path, "120");
+
+    const frequency = await device.filterCutOffFrequencyStage4();
+
+    expect(frequency).toBe(120);
+  });
+
+  it("writes the comb filter frequency register when applicable", async () => {
+    fakeClient.cache.set(commands.dseFilterModeStage2().path, "13089");
+
+    await device.setFilterCutOffFrequencyStage2(200);
+
+    expect(fakeClient.setCalls.at(-1)).toEqual({
+      path: commands.dseCombFilterFrequencyStage2().path,
+      value: 200
+    });
+  });
+
+  it("returns zero frequency when no filter is active", async () => {
+    const frequency = await device.filterCutOffFrequencyStage3();
+
+    expect(frequency).toBe(0);
+  });
+
+  it("aggregates the configuration of all filter stages", async () => {
+    fakeClient.cache.set(commands.dseFilterModeStage2().path, "13089");
+    fakeClient.cache.set(commands.dseCombFilterFrequencyStage2().path, "180");
+    fakeClient.cache.set(commands.dseFilterModeStage3().path, "13105");
+    fakeClient.cache.set(commands.dseMovAvFilterFrequencyStage3().path, "90");
+    fakeClient.cache.set(commands.dseFilterModeStage5().path, "13108");
+    fakeClient.cache.set(commands.dseMovAvFilterFrequencyStage5().path, "60");
+
+    const configuration = await device.filterStagesConfiguration();
+
+    expect(configuration).toEqual([
+      { stage: 2, mode: FilterType.FIRCombFilter, cutOffFrequency: 180 },
+      { stage: 3, mode: FilterType.FIRMovingAverage, cutOffFrequency: 90 },
+      { stage: 4, mode: FilterType.NoFilter, cutOffFrequency: 0 },
+      { stage: 5, mode: FilterType.FIRMovingAverage, cutOffFrequency: 60 }
+    ]);
+  });
+
+  it("updates mode and frequency in a single call", async () => {
+    await device.configureFilterStage(3, {
+      mode: FilterType.FIRMovingAverage,
+      cutOffFrequency: 120
+    });
+
+    const lastCalls = fakeClient.setCalls.slice(-2);
+
+    expect(lastCalls[0]).toEqual({
+      path: commands.dseFilterModeStage3().path,
+      value: 13105
+    });
+    expect(lastCalls[1]).toEqual({
+      path: commands.dseMovAvFilterFrequencyStage3().path,
+      value: 120
+    });
+  });
+});
+
+const FILTER_STAGE_PATHS = [
+  commands.dseFilterModeStage2().path,
+  commands.dseFilterModeStage3().path,
+  commands.dseFilterModeStage4().path,
+  commands.dseFilterModeStage5().path
+];


### PR DESCRIPTION
## Summary
- expose aggregate helpers on the DSE device to read and update filter stages and validate them through unit tests
- add backend APIs to list and update filter stage modes/cut-off frequencies and map enum values to friendly strings
- build a Settings page panel to view and edit each stage's filter mode/frequency with form validation and refresh controls

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e6b9b2eb2c8333b98d54a568b9168b